### PR TITLE
Preserve auth information when reading the body from a file

### DIFF
--- a/cli/run/command.go
+++ b/cli/run/command.go
@@ -230,12 +230,12 @@ func run(opts *options.RunCommandOptions) error {
 				readFrom = os.Getenv(readFrom)
 			}
 
-			data, err = ioutil.ReadFile(readFrom)
+			body, err := ioutil.ReadFile(readFrom)
 			if err != nil {
 				return err
 			}
 
-			content = string(data)
+			content = string(body)
 		}
 
 		if !openBodyEditor && readFrom == "" {


### PR DESCRIPTION
When reading the body from a file, don't overwrite the data variable which breaks auth parsing